### PR TITLE
Add monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
 
-config.transformer.minifierPath = "metro-minify-esbuild";
+config.transformer.minifierPath = require.resolve("metro-minify-esbuild");
 config.transformer.minifierConfig = {
   // ESBuild options...
 };


### PR DESCRIPTION
I had issues using this in a monorepo, where it said it couldn't resolve the `minifierPath`. I solved it with `require.resolve`.